### PR TITLE
serverless-with-nosql-database: Update explore-run-queries instructions

### DIFF
--- a/serverless-with-nosql-database/explore-run-queries/explore-run-queries.md
+++ b/serverless-with-nosql-database/explore-run-queries/explore-run-queries.md
@@ -50,6 +50,7 @@ The goal of this task is to understand the difference between the 2 data models 
     <copy>
     cd ~/serverless-with-nosql-database/express-nosql
     npm install
+    npm install oracle-nosqldb --save
     node express-oracle-nosql.js &
     </copy>
     ```
@@ -133,6 +134,7 @@ The goal of this task is to understand the difference between the 2 data models 
     <copy>
     cd ~/serverless-with-nosql-database/express-nosql
     npm install
+    npm install oracle-nosqldb --save
     node express-baggage-demo-nosql.js &
     </copy>
     ````


### PR DESCRIPTION
This PR updates the serverless-with-nosql-database LiveLabs to use the latest version of Node.js for Oracle NoSQL Database.

> LiveLab code is deploying the version 5.2. The latest version introduced support for new regions. 
> Instead of fixing the code, I fixed the instructions in the explore-run-queries to be sure that end-user will use the latest version.

```
    npm install
    npm install oracle-nosqldb --save
```

Signed-off-by: Dario Vega dario.vega@oracle.com