### PR TITLE
11392 (sandbox): add Oracle CloudWorld 2023 support page

### DIFF
--- a/23cfree/workshops/sandbox-js-generic/manifest.json
+++ b/23cfree/workshops/sandbox-js-generic/manifest.json
@@ -51,6 +51,10 @@
         "title": "Need Help?",
         "description": "Instructions for getting help",
         "filename":"https://raw.githubusercontent.com/oracle-livelabs/common/main/labs/need-help/need-help-freetier.md"
+      },
+      {
+        "title": "Oracle CloudWorld 2023 - Support", 
+        "filename": "https://oracle-livelabs.github.io/common/support/ocwsupportlab/ocwsupportlab.md"
       }
   ]
 }


### PR DESCRIPTION
# Workshop ID 11392

adding the Oracle Cloud World Support page to the workshop's `manifest.json` as requested. No further changes.