### PR TITLE
WMS ID: 11283

### DIFF
--- a/xmldb/provision/provision.md
+++ b/xmldb/provision/provision.md
@@ -76,7 +76,7 @@ In this lab, you will:
 <if type="livelabs">
     - __Choose a compartment__ - Use the default compartment that includes your user id.
 </if>
-    - __Display Name__ - Enter a memorable name for the database for display purposes. For this lab, use __TEXTDB__.
+    - __Display Name__ - Enter a memorable name for the database for display purposes. For this lab, use __XMLDB__.
 <if type="freetier">
     - __Database Name__ - Use letters and numbers only, starting with a letter. Maximum length is 14 characters. (Underscores not initially supported.) For this lab, use __TEXTDB__.
 

--- a/xmldb/queries/queries.md
+++ b/xmldb/queries/queries.md
@@ -49,13 +49,13 @@ The W3C XQuery link: [W3C Xquery] (https://www.w3.org/TR/xquery-31/)
 SQL/XML functions, XMLQuery, XMLTable, XMLExists, and XMLCast, are defined by the SQL/XML standard as a general interface between SQL and XQuery languages. Using these functions, you can construct XML data using relational data, query relational data as if it were XML data, and construct relational data from XML data.
 
 Here is a short overview of these SQL/XML functions:
--	XMLQuery - Use this function to construct or query XML data. It takes an XQuery expression as an argument and returns the result of evaluating the XQuery expression, as an XMLType instance. 
+-	XMLQuery - Use this function to construct or query XML data. It takes an XQuery expression as an argument and returns the result of evaluating the XQuery expression, as an XMLType instance. (Example in Task 4.3)
 
--	XMLTable - Use this function XMLTable to decompose the result of an XQuery-expression evaluation into the relational rows and columns of a new, virtual table. You can insert this data into a pre-existing database table, or you can query it using SQL — in a join expression, for example. 
+-	XMLTable - Use this function XMLTable to decompose the result of an XQuery-expression evaluation into the relational rows and columns of a new, virtual table. You can insert this data into a pre-existing database table, or you can query it using SQL — in a join expression, for example. (Example in Task 4.5)
 
--	XMLExists - Use this function to check whether a given XQuery expression returns a non-empty XQuery sequence. If so, the function returns TRUE. Otherwise, it returns FALSE. 
+-	XMLExists - Use this function to check whether a given XQuery expression returns a non-empty XQuery sequence. If so, the function returns TRUE. Otherwise, it returns FALSE. (Example in Task 4.2)
 
--	XMLCast - Use this function to cast an XQuery value to a SQL data type. 
+-	XMLCast - Use this function to cast an XQuery value to a SQL data type. (Example in Task 4.4)
 
 Here is the link for more information: [XQL/XML functions] (https://docs.oracle.com/en/database/oracle/oracle-database/21/adxdb/xquery-and-XML-DB.html#GUID-4805CF1C-A00D-4B88-AF2E-00A9DB6F3392)
 

--- a/xmldb/update/update.md
+++ b/xmldb/update/update.md
@@ -1,7 +1,7 @@
 # Update XML content
 
 ## Introduction
-This lab will use the SQL Workshop in Database Actions from the Autonomous Transaction Processing page. In this lab, we will explore XQuery to update XML content in Oracle XML DB. XQuery is one of the main ways that you interact with XML data in Oracle XML DB. It is the W3C language designed for querying and updating XML data. 
+This lab will use the SQL Workshop in Database Actions from the Autonomous Transaction Processing page. In this lab, we will explore XQuery to update and manipulate XML content in Oracle XML DB. XQuery is one of the main ways that you interact with XML data in Oracle XML DB. It is the W3C language designed for querying and updating XML data. 
 
 The support for the XQuery Language is provided through a native implementation of SQL/XML functions: XMLQuery, XMLTable, XMLExists, and XMLCast. These SQL/XML functions are defined by the SQL/XML standard as a general interface between the SQL and XQuery languages.
 
@@ -45,13 +45,13 @@ The W3C XQuery link: [W3C Xquery] (https://www.w3.org/TR/xquery-31/)
 SQL/XML functions, XMLQuery, XMLTable, XMLExists, and XMLCast, are defined by the SQL/XML standard as a general interface between SQL and XQuery languages. Using these functions, you can construct XML data using relational data, query relational data as if it were XML data, and construct relational data from XML data.
 
 Here is a short overview of these SQL/XML functions:
--	XMLQuery - Use this function to construct or query XML data. It takes an XQuery expression as an argument and returns the result of evaluating the XQuery expression, as an XMLType instance. 
+-	XMLQuery - Use this function to construct or query XML data. It takes an XQuery expression as an argument and returns the result of evaluating the XQuery expression, as an XMLType instance. (Example in Task 4.2)
 
 -	XMLTable - Use this function XMLTable to decompose the result of an XQuery-expression evaluation into the relational rows and columns of a new, virtual table. You can insert this data into a pre-existing database table, or you can query it using SQL — in a join expression, for example. 
 
--	XMLExists - Use this function to check whether a given XQuery expression returns a non-empty XQuery sequence. If so, the function returns TRUE. Otherwise, it returns FALSE. 
+-	XMLExists - Use this function to check whether a given XQuery expression returns a non-empty XQuery sequence. If so, the function returns TRUE. Otherwise, it returns FALSE. (Example in Task 4.2)
 
--	XMLCast - Use this function to cast an XQuery value to a SQL data type. 
+-	XMLCast - Use this function to cast an XQuery value to a SQL data type. (Example in Task 4.5)
 
 Here is the link for more information: [XQL/XML functions] (https://docs.oracle.com/en/database/oracle/oracle-database/21/adxdb/xquery-and-XML-DB.html#GUID-4805CF1C-A00D-4B88-AF2E-00A9DB6F3392)
 


### PR DESCRIPTION
# Comments on the changes
Update XMLDB course, more consistant naming, and pointing to examples
## Notes
In Lab 1 (Task 2.3, and video), we name the database TEXTDB
In Lab 2 (Task 1.6) the database is referred as XMLDB
In Lab 3 (Task 3.6) the database is referred as XMLDB
In Lab 4 (Task 1.6) the database is referred as XMLDB
In Lab 5 (Task 2.6) the database is referred as XMLDB
In Lab 6 (Task 1.6) the database is referred as XMLDB
In Lab 7 (Task 3.6) the database is referred as XMLDB

In Lab 3 and Lab 7, it would be really helpful to have examples on each section, maybe not for everything but some can help to fully understand the languages described, that said it’s nice that a reference to an extensive description is added (for Query and SQL/XML)
I like the fact that these are self contained and that someone can refer to a specific Lab and know everything they need, but it seems a bit redundant to have Task 1, Task 2 and Task 3 the exact same in both Labs (Lab 3 and Lab 7). Perhaps this is because Tasks 1 and 2 are not steps in the process, they’re explanation of the language instead.
The introduction to both Labs is very similar and almost the same, but with minor changes, these changes aren’t regarding the main porpoise of the Lab. Although the Objectives in both Labs are spot on.
To not make heavy changes I suggest maintaining most as it is, but add a little comment to see an example on the same Lab.

As an aditional comment, I’ll add that some of the walk-through videos are too fast to keep on, the first one I saw I was trying to keep up with, until I realized I should be doing the Tasks first and refer the the video for extra visual support. In my case it would’ve been really helpful if the videos were slower.

Besides this the course is good, and introduces most things you can use.