### PR TITLE
Clarify finance case-processing capacity terminology

### DIFF
--- a/livestack-workshop-finance/conclusion-business-outcomes/conclusion-business-outcomes.md
+++ b/livestack-workshop-finance/conclusion-business-outcomes/conclusion-business-outcomes.md
@@ -6,7 +6,7 @@ You have now walked through the core Seer Bank finance decision path: understand
 
 The important takeaway is practical: you can now explain how one finance question can move across several data types without breaking the chain of evidence.
 
-A risk leader may start with a dashboard KPI. A developer may need the transaction as JSON. A fraud analyst may need relationship paths. A service leader may need distance and capacity. A planner may need a prediction. Those are different jobs, but they should not require disconnected data copies and separate explanations.
+A risk leader may start with a dashboard KPI. A developer may need the transaction as JSON. A fraud analyst may need relationship paths. A service leader may need distance and case-processing capacity. A planner may need a prediction. Those are different jobs, but they should not require disconnected data copies and separate explanations.
 
 With Oracle Database 26ai, Seer Bank can use the right capability for each question while keeping the evidence connected: relational SQL for operations, JSON Relational Duality for application documents, AI Vector Search for meaning, Property Graph for relationships, Oracle Spatial for location, and OML for prediction.
 
@@ -66,7 +66,7 @@ Review what you saw and connect each outcome back to the business question it he
     | --- | --- |
     | Emerging risk and fraud signals | Signal text, product exposure, transactions, and graph relationships can be investigated without moving evidence across systems. |
     | Application delivery | JSON documents and relational analytics can come from the same governed transaction model. |
-    | Client service and operational capacity | Spatial coverage, service centers, demand regions, and SLA zones can be analyzed together. |
+    | Client service and case-processing capacity | Spatial coverage, service centers, demand regions, and SLA zones can be analyzed together. |
     | Predictive planning | OML scores run close to the finance records that supply model features and business context. |
     | Governance and explainability | Teams can point to database-backed evidence instead of reconciling multiple copies of the truth. |
 

--- a/livestack-workshop-finance/introduction/introduction.md
+++ b/livestack-workshop-finance/introduction/introduction.md
@@ -29,7 +29,7 @@ The hands-on work follows one finance decision flow. First, you orient yourself 
 
 Each lab starts with a practical finance question and then shows the SQL evidence behind the answer.
 
-As you move through the labs, treat every query as part of the same operating record. The dashboard numbers are not isolated metrics. They point to products, transactions, signals, relationships, service capacity, and predictions that all remain connected inside Oracle Database.
+As you move through the labs, treat every query as part of the same operating record. The dashboard numbers are not isolated metrics. They point to products, transactions, signals, relationships, case-processing capacity, and predictions that all remain connected inside Oracle Database.
 
 The image below is the Seer Bank Finance LiveStack welcome page. It introduces the application as one connected financial-intelligence journey: monitor risk, investigate exposure, route work, analyze capacity, and use predictive evidence. The workshop uses SQL to explain the database evidence behind those same application pages.
 

--- a/livestack-workshop-finance/predictive-risk-oml/predictive-risk-oml.md
+++ b/livestack-workshop-finance/predictive-risk-oml/predictive-risk-oml.md
@@ -13,9 +13,9 @@ You use the same governed finance records to support planning decisions. The rec
 
 A **model** is a trained pattern that can score new or current data. In this lab, OML models help estimate outcomes such as demand surge, revenue impact, or product grouping from the finance records already in Oracle Database.
 
-A **feature** is an input value used by a model. Features can come from product activity, risk severity, transaction attributes, customer behavior, service capacity, or revenue history. Good features translate raw finance records into signals the model can learn from.
+A **feature** is an input value used by a model. Features can come from product activity, risk severity, transaction attributes, customer behavior, case-processing capacity, or revenue history. Good features translate raw finance records into signals the model can learn from.
 
-**Classification** predicts a category or label, such as `SURGE` or `STABLE`. This is useful when the business decision is a choice between states, such as whether a product is likely to need more service capacity.
+**Classification** predicts a category or label, such as `SURGE` or `STABLE`. This is useful when the business decision is a choice between states, such as whether a product is likely to need more case-processing capacity for reviews, outreach, or support work.
 
 **Regression** predicts a number, such as expected revenue, forecasted load, or estimated impact. This is useful when planners need a measurable value rather than a yes/no label.
 
@@ -25,11 +25,11 @@ A **feature** is an input value used by a model. Features can come from product 
 
 </details>
 
-The first image below explains the OML scoring flow. Product, transaction, risk, client, revenue, and service-capacity data become model features; Oracle Machine Learning scores the models inside the database; and the results return to SQL as labels, clusters, forecasts, probabilities, and operational risk signals.
+The first image below explains the OML scoring flow. Product, transaction, risk, client, revenue, and case-processing capacity data become model features; Oracle Machine Learning scores the models inside the database; and the results return to SQL as labels, clusters, forecasts, probabilities, and operational risk signals.
 
 ![Finance OML scoring flow](images/finance-oml-scoring-flow.svg " ")
 
-The second image is the Predictive Risk, Capacity and Revenue page. It gives finance teams a business-facing view of product risk, client segments, revenue forecast quality, product cohorts, and service capacity pressure. The SQL in this lab shows how those predictive results can be inventoried and scored inside Oracle Database instead of being disconnected in a separate notebook or external model service.
+The second image is the Predictive Risk, Capacity and Revenue page. It gives finance teams a business-facing view of product risk, client segments, revenue forecast quality, product cohorts, and case-processing pressure. In this financial-services context, capacity means the ability of teams or service centers to absorb review, support, onboarding, dispute, fraud, or AML work. The SQL in this lab shows how those predictive results can be inventoried and scored inside Oracle Database instead of being disconnected in a separate notebook or external model service.
 
 ![Predictive Risk Capacity and Revenue page](images/predictive-risk-oml.png " ")
 
@@ -178,7 +178,7 @@ Perform the following set of steps to score demand risk and revenue directly in 
 3. Compare actual target revenue to predicted revenue.
     The demand query classifies product pressure from stored finance features, and the revenue query estimates a transaction outcome from customer, order, and fulfillment attributes.
 
-    The demand query returns predicted surge labels with confidence, which helps product and operations teams decide where to watch capacity or risk pressure. The revenue query compares known target revenue to predicted revenue, which helps reviewers understand whether the model is directionally useful for planning.
+    The demand query returns predicted surge labels with confidence, which helps product and operations teams decide where to watch case-processing or risk pressure. The revenue query compares known target revenue to predicted revenue, which helps reviewers understand whether the model is directionally useful for planning.
 
     Both queries score persisted models without leaving Oracle Database. That keeps sensitive finance records close to the models and gives technical teams SQL evidence for each prediction.
 

--- a/livestack-workshop-finance/risk-operations-dashboard/risk-operations-dashboard.md
+++ b/livestack-workshop-finance/risk-operations-dashboard/risk-operations-dashboard.md
@@ -40,7 +40,7 @@ Estimated Time: **10 minutes**
 
 | Step | Finance focus |
 | --- | --- |
-| Business Problem | Risk teams need a shared view of exposure, transaction pressure, and service capacity. |
+| Business Problem | Risk teams need a shared view of exposure, transaction pressure, and case-processing capacity. |
 | Technical Challenge | App and data teams need one explainable query path instead of separate pipelines for signals, products, transactions, and service data. |
 | Persona Focus | Risk operations leaders read the dashboard; database and application developers show where the dashboard evidence comes from. |
 | What You Will See | Dashboard metrics are database-backed and can be explained with SQL. |
@@ -93,7 +93,7 @@ Start with the KPI query that explains the top-level dashboard numbers.
 
     Exposure adds scale to severity. Criticality tells you how serious a signal appears; exposure tells you how widely that signal may matter. A lower-severity issue with very high exposure may still deserve attention because it can affect many clients, generate more cases, or draw operational and regulatory scrutiny.
 
-    The high-risk count is the number of signals with a criticality score of 80 or higher. A higher count means more issues may need immediate analyst review, case triage, or automated follow-up from the operations agent. It does not mean every item is confirmed fraud or a confirmed incident; it means the dashboard has found more items that cross the bank's review threshold.
+    The high-risk count is the number of signals with a criticality score of 80 or higher. A higher count means more issues may need immediate analyst review, case triage, or operational follow-up. It does not mean every item is confirmed fraud or a confirmed incident; it means the dashboard has found more items that cross the bank review threshold.
 
 ## Task 2: Find top product exposure
 

--- a/livestack-workshop-finance/risk-signal-vector-search/risk-signal-vector-search.md
+++ b/livestack-workshop-finance/risk-signal-vector-search/risk-signal-vector-search.md
@@ -96,7 +96,7 @@ Search for financial products related to mortgage pre-approval risk by meaning, 
 
     The expected top result is `Mortgage Pre-Approval`, followed by related lending and risk analytics products. The ranking matters because it acts like an analyst assistant: it brings likely matches to the top even when the search phrase and product name are not identical.
 
-    In the broader workflow, these ranked products can become the next filter for dashboard review, product exposure analysis, or an operations agent action.
+    In the broader workflow, these ranked products can become the next filter for dashboard review, product exposure analysis, or operational follow-up.
 
 ## Task 2: Search risk signals by meaning
 

--- a/livestack-workshop-finance/service-sla-spatial/service-sla-spatial.md
+++ b/livestack-workshop-finance/service-sla-spatial/service-sla-spatial.md
@@ -2,26 +2,28 @@
 
 ## Introduction
 
-After risk is identified, Seer Bank needs to know whether service capacity is close enough to respond. This lab uses **Oracle Spatial** to answer a practical operations question: where is demand, where are the service centers, and how quickly can the bank respond?
+After risk is identified, Seer Bank needs to know whether case-processing capacity is close enough to respond. This lab uses **Oracle Spatial** to answer a practical operations question: where is demand, where are the service centers, and how quickly can the bank respond?
 
-Risk and fraud decisions often create service work: client outreach, case routing, product review, and document handling. Spatial analysis helps operations leaders avoid guessing from a map and instead measure whether service capacity is near the demand region that needs support.
+Risk and fraud decisions often create service work: client outreach, case routing, AML or fraud review, product review, dispute follow-up, onboarding checks, and document handling. Spatial analysis helps operations leaders avoid guessing from a map and instead measure whether case-processing capacity is near the demand region that needs support.
 
 Every risk decision can create operational work. The bank needs to know not only what is risky, but whether the service network can respond where demand is highest.
 
 <details>
-<summary>Key terms: spatial data, point, boundary, distance, GeoJSON, and SLA</summary>
+<summary>Key terms: spatial data, point, boundary, distance, GeoJSON, SLA, and case-processing capacity</summary>
 
 **Spatial data** describes location or shape. A service center can be stored as a point, a demand region can be stored as a boundary, and an SLA zone can be stored as an area. Spatial data lets operations teams ask location-aware questions with SQL.
 
 A **point** is a precise map location, usually represented by longitude and latitude. In this lab, a service center point tells the database where work can be handled.
 
-A **boundary** is a shape around an area, such as a metro region or service zone. Boundaries let the database compare where demand is located against where service capacity is available.
+A **boundary** is a shape around an area, such as a metro region or service zone. Boundaries let the database compare where demand is located against where case-processing capacity is available.
 
-**Distance** tells you how far one location is from another location or boundary. In service planning, distance helps answer whether a center is close enough to respond, whether capacity is practical for a region, and where routing pressure may appear.
+**Distance** tells you how far one location is from another location or boundary. In service planning, distance helps answer whether a center is close enough to respond, whether case-processing capacity is practical for a region, and where routing pressure may appear.
 
 **GeoJSON** is a JSON format for representing map features such as points, lines, and areas. Oracle can convert spatial objects into GeoJSON so the same governed geometry can support both SQL analysis and map-based application screens.
 
-An **SLA**, or service-level agreement, is a response-time or service-level commitment. In this workshop, SLA coverage connects geography to operations: the question is not only whether a risk exists, but whether the bank has service capacity near the region that needs help.
+An **SLA**, or service-level agreement, is a response-time or service-level commitment. In this workshop, SLA coverage connects geography to operations: the question is not only whether a risk exists, but whether the bank has case-processing capacity near the region that needs help.
+
+**Case-processing capacity** means the operational ability of the bank to handle finance-related work, not inventory or data-center capacity. In this lab, that work can include client outreach, fraud follow-up, AML review, dispute handling, onboarding checks, product review, or document processing. The spatial question is whether enough of that handling capacity is close to the region where demand or risk is building.
 
 </details>
 
@@ -29,7 +31,7 @@ The first image below explains the spatial coverage pattern. Service centers are
 
 ![Spatial service coverage flow](images/spatial-service-coverage-flow.svg " ")
 
-The second image is the Client Service and SLA Coverage page. It combines a map, service-center table, regional demand indicators, and capacity alerts so an operations leader can see where demand is building and whether nearby service capacity is enough to respond. The SQL in this lab queries the same location and SLA data behind that screen.
+The second image is the Client Service and SLA Coverage page. It combines a map, service-center table, regional demand indicators, and case-processing capacity alerts so an operations leader can see where demand is building and whether nearby case-processing capacity is enough to respond. The SQL in this lab queries the same location and SLA data behind that screen.
 
 ![Client Service and SLA Coverage map](images/service-sla-spatial.png " ")
 
@@ -44,14 +46,14 @@ Estimated Time: **10 minutes**
 
 | Step | Finance focus |
 | --- | --- |
-| Business Problem | Service leaders need to know whether capacity is close enough to high-demand regions. |
+| Business Problem | Service leaders need to know whether case-processing capacity is close enough to high-demand regions. |
 | Technical Challenge | Operations teams need location-aware decisions without moving geography, service centers, and SLA zones into separate mapping systems. |
 | Persona Focus | Service operations leaders evaluate coverage; database developers show distance and SLA evidence with spatial SQL. |
 | What You Will See | Spatial data can quantify distance and regional service pressure in SQL. |
 | Database Capability | SDO\_GEOMETRY, SDO\_GEOM.SDO\_DISTANCE, regions, and SLA zones support coverage analysis. |
-| Outcome | Operations teams can prioritize service capacity based on geography and demand. |
+| Outcome | Operations teams can prioritize case-processing capacity based on geography and demand. |
 
-Persona focus: You support a service operations leader by turning location data into queryable coverage evidence for capacity and SLA decisions.
+Persona focus: You support a service operations leader by turning location data into queryable coverage evidence for case-processing and SLA decisions.
 
 ## Task 1: Calculate service center distance to New York Metro
 
@@ -111,7 +113,7 @@ Start by comparing service-center locations to the New York Metro demand region.
 
     Expected nearest service center: Edison Wealth Service Center. New York Metro has demand index 91.
 
-    The distance column tells operations which service centers can respond fastest to a high-demand region. The demand index explains why the region matters: a high-demand area may need more capacity, closer routing, or stricter monitoring when risk signals increase.
+    The distance column tells operations which service centers can respond fastest to a high-demand region. The demand index explains why the region matters: a high-demand area may need more case-processing capacity, closer routing, or stricter monitoring when risk signals increase.
 
 ## Task 2: Summarize SLA zone coverage
 


### PR DESCRIPTION
## Summary
- Clarify that capacity in the finance workshop means case-processing capacity, not inventory or infrastructure capacity
- Update Labs 6 and 7 with financial-services examples such as AML review, fraud follow-up, onboarding checks, disputes, and document processing
- Clean stale operations-agent wording in active labs and align intro/conclusion references

## Validation
- rg scan confirmed no remaining "service capacity" phrasing in the Finance workshop markdown/manifests
- git diff --check passed for livestack-workshop-finance
- LiveLabs workshop QA completed; formatting checks passed, with broader pre-existing Lanham style warnings reported by the validator